### PR TITLE
fixed flag not respawning / dying when leaving map / hitting death tiles

### DIFF
--- a/src/game/server/gamemodes/DDRace.cpp
+++ b/src/game/server/gamemodes/DDRace.cpp
@@ -255,9 +255,6 @@ void CGameControllerDDRace::Tick()
 	IGameController::Tick();
 	m_Teams.Tick();
 
-	// if(Server()->IsSixup(0))
-	// 	GameServer()->SendGameMsg(protocol7::GAMEMSG_CTF_GRAB, 0, -1);
-
 
 	if(!idm)
 		for(int fi = 0; fi < 2; fi++)
@@ -268,13 +265,13 @@ void CGameControllerDDRace::Tick()
 				continue;
 
 			// flag hits death-tile or left the game layer, reset it
-			// if(GameServer()->Collision()->GetCollisionAt(F->m_Pos.x, F->m_Pos.y)&CCollision::COLFLAG_DEATH || F->GameLayerClipped(F->m_Pos))
-			// {
-			// 	GameServer()->Console()->Print(IConsole::OUTPUT_LEVEL_DEBUG, "game", "flag_return");
-			// 	GameServer()->CreateSoundGlobal(SOUND_CTF_RETURN);
-			// 	F->Reset();
-			// 	continue;
-			// }
+			if(GameServer()->Collision()->GetCollisionAt(F->m_Pos.x, F->m_Pos.y) == TILE_DEATH || F->GameLayerClipped(F->m_Pos))
+			{
+				GameServer()->Console()->Print(IConsole::OUTPUT_LEVEL_DEBUG, "game", "flag_return");
+				GameServer()->CreateSoundGlobal(SOUND_CTF_RETURN);
+				F->Reset();
+				continue;
+			}
 
 			//
 			if(F->m_pCarryingCharacter)


### PR DESCRIPTION
Fixes flags not respawning when out of bounds / hitting death tiles
Tested in game
