### PR TITLE
fix flag behaviour with rollback whilst half dead

### DIFF
--- a/src/game/server/gamemodes/DDRace.cpp
+++ b/src/game/server/gamemodes/DDRace.cpp
@@ -362,12 +362,12 @@ void CGameControllerDDRace::Tick()
 			F->m_Positions[Server()->Tick() % POSITION_HISTORY] = F->m_Pos;
 
 			//
-			if(F->m_pCarryingCharacter && F->m_pCarryingCharacter->m_DeathTick == -1)
+			if(F->m_pCarryingCharacter)
 			{
 				// update flag position
 				F->m_Pos = F->m_pCarryingCharacter->m_Pos;
 
-				if(m_apFlags[fi^1] && m_apFlags[fi^1]->m_AtStand)
+				if(m_apFlags[fi^1] && m_apFlags[fi^1]->m_AtStand && F->m_pCarryingCharacter->m_DeathTick == -1)
 				{
 					if(distance(F->m_Pos, m_apFlags[fi^1]->m_Pos) < CFlag::ms_PhysSize + CCharacter::ms_PhysSize)
 					{


### PR DESCRIPTION
Fixes flags being able to be picked up from a player before that player has died from delayed death due to rollback

## Checklist

- [X] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test if it works standalone, system.c especially
- [ ] Considered possible null pointers and out of bounds array indexing
- [ ] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
