### PR TITLE
make team spawn random with idm

### DIFF
--- a/src/game/server/gamecontroller.cpp
+++ b/src/game/server/gamecontroller.cpp
@@ -194,9 +194,10 @@ bool IGameController::CanSpawn(int Team, vec2 *pOutPos, int DDTeam)
 	}
 	else
 	{
+		bool randomTeam = rand() % 2;
 		EvaluateSpawnType(&Eval, 0, DDTeam);
-		EvaluateSpawnType(&Eval, 1, DDTeam);
-		EvaluateSpawnType(&Eval, 2, DDTeam);
+		EvaluateSpawnType(&Eval, 1+randomTeam, DDTeam);
+		EvaluateSpawnType(&Eval, 1+!randomTeam, DDTeam);
 	}
 
 	*pOutPos = Eval.m_Pos;
@@ -561,7 +562,9 @@ void IGameController::OnReset()
 
 bool IGameController::IsTeamplay() const
 {
-	return m_GameFlags&GAMEFLAG_TEAMS;
+	if (idm) return false;
+	return true;
+	// return m_GameFlags&GAMEFLAG_TEAMS;
 }
 
 int IGameController::OnCharacterDeath(class CCharacter *pVictim, class CPlayer *pKiller, int Weapon)


### PR DESCRIPTION
spawns seemed to go consistently to red spawns with idm, hopefully this fixes it

## Checklist

- [ ] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test if it works standalone, system.c especially
- [ ] Considered possible null pointers and out of bounds array indexing
- [ ] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
